### PR TITLE
Correct secrets token handling

### DIFF
--- a/.github/workflows/local_updates.yaml
+++ b/.github/workflows/local_updates.yaml
@@ -10,4 +10,4 @@ jobs:
     with:
       os: ubuntu-latest
     secrets:
-      pat: ${{ secrets.token }}
+      pat: ${{ secrets.PAT }}


### PR DESCRIPTION
I was not consistent with names, so the token was not found. All secrets now called PAT.

Closes #5
