### PR TITLE
Correct branch ref in update_nix

### DIFF
--- a/.github/workflows/update_nix.yaml
+++ b/.github/workflows/update_nix.yaml
@@ -24,7 +24,9 @@ jobs:
         run: nix flake update -v --commit-lock-file
       - name: Push commits
         if: ${{ github.event_name == 'pull_request' }}
-        run: git push origin ${{ github.ref_name }}
+        env:
+          BRANCH: ${{ github.head_ref }}
+        run: git push origin "$BRANCH"
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v7
         if: ${{ github.event_name != 'pull_request' && contains(github.ref, 'main')}}


### PR DESCRIPTION
When pushing on a PR, the branch name is in github.head_ref

Closes #7
